### PR TITLE
allow perf_event_paranoid=-1

### DIFF
--- a/src/session/record_session.rs
+++ b/src/session/record_session.rs
@@ -2727,7 +2727,7 @@ fn check_perf_event_paranoid() {
             }
             Ok(siz) => {
                 let int_str = String::from_utf8_lossy(&buf[0..siz]);
-                let maybe_val = int_str.trim().parse::<usize>();
+                let maybe_val = int_str.trim().parse::<isize>();
                 match maybe_val {
                     Ok(val) if val > 1 => {
                         clean_fatal!("rd needs `/proc/sys/kernel/perf_event_paranoid` <= 1, but it is {}.\n\


### PR DESCRIPTION
This previously failed with
`Error while parsing file '/proc/sys/kernel/perf_event_paranoid': ParseIntError { kind: InvalidDigit }`

---
_Note_: `perf_event_paranoid=-1` is probably a bad idea. :slightly_smiling_face: 