### PR TITLE
Use 1 codegen unit in release builds to further optimize the build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ verify_syscall_numbers = []
 
 [profile.release]
 lto = true
+codegen-units = 1


### PR DESCRIPTION
This makes the final binary slightly smaller and faster.

Note that I couldn't build locally (I ran into the same issue as https://github.com/sidkshatriya/rd/issues/4, despite installing `capnproto-dev` on Fedora 33).